### PR TITLE
Add config option to select between provider specific message formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ type = lge450
 port = /dev/ttyUSB0
 # optional encryption key
 key = 
+# electricity provider, the same meter type can return data in provider specific formats
+provider = EKZ
 
 [sink0]
 # type of the sink

--- a/smartmeter_datacollector/config.py
+++ b/smartmeter_datacollector/config.py
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = {
         'port': "/dev/ttyUSB0",
         'baudrate': 2400,
         'key': "",
+        'provider': "EKZ"
     },
     'sink0': {
         'type': "logger",

--- a/smartmeter_datacollector/smartmeter/hdlc_dlms_parser.py
+++ b/smartmeter_datacollector/smartmeter/hdlc_dlms_parser.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from gurux_dlms import GXByteBuffer, GXDLMSClient, GXReplyData
 from gurux_dlms.enums import InterfaceType, ObjectType, Security
-from gurux_dlms.objects import GXDLMSData, GXDLMSObject, GXDLMSRegister, GXDLMSPushSetup, GXDLMSClock, GXDLMSCaptureObject
+from gurux_dlms.objects import (GXDLMSCaptureObject, GXDLMSClock, GXDLMSData, GXDLMSObject, GXDLMSPushSetup,
+                                GXDLMSRegister)
 from gurux_dlms.secure import GXDLMSSecureClient
 
 from .cosem import Cosem
@@ -98,16 +99,22 @@ class HdlcDlmsParser:
                         # Skip first (meta-data) object
                         continue
                     self._client.updateValue(obj, attr_ind, self._dlms_data.value[index])
-                    LOGGER.debug("%s %s %s: %s", obj.objectType, obj.logicalName, attr_ind, obj.getValues()[attr_ind - 1])
+                    LOGGER.debug(
+                        "%s %s %s: %s",
+                        obj.objectType,
+                        obj.logicalName,
+                        attr_ind,
+                        obj.getValues()[
+                            attr_ind - 1])
             elif msg_format == 2:
                 # Used by Stromnetz Graz
                 # message contains timestamp + OBIS code/value pairs
-                p =  GXDLMSPushSetup()
+                p = GXDLMSPushSetup()
                 # fill setup with definitions
                 # first element is clock
                 p.pushObjectList.append((GXDLMSClock(), GXDLMSCaptureObject(2, 0)))
                 # every second element after that is the OBIS code
-                for idx in range(1,len(self._dlms_data.value),2):
+                for idx in range(1, len(self._dlms_data.value), 2):
                     assert isinstance(self._dlms_data.value[idx], bytearray)
                     assert len(self._dlms_data.value[idx]) == 6
                     # convert bytearray to list of ints, map ints to str and add a dot between each element
@@ -117,7 +124,7 @@ class HdlcDlmsParser:
                 assert len(parsed_objects) == (len(self._dlms_data.value) + 1) / 2
                 # Add values
                 object_idx = 0  # index of the pushObjectList
-                for idx in range(0,len(self._dlms_data.value),2):  # index of the message contents
+                for idx in range(0, len(self._dlms_data.value), 2):  # index of the message contents
                     if idx == 0:
                         # first the timestamp
                         assert isinstance(self._dlms_data.value[idx], bytearray)
@@ -128,13 +135,21 @@ class HdlcDlmsParser:
                     obj = parsed_objects[object_idx][0]
                     attr_ind = parsed_objects[object_idx][1]
                     self._client.updateValue(obj, attr_ind.attributeIndex, self._dlms_data.value[idx])
-                    LOGGER.debug("%d %s %s %s: %s", object_idx, obj.objectType, obj.logicalName, attr_ind.attributeIndex, obj.getValues()[attr_ind.attributeIndex - 1])
+                    LOGGER.debug(
+                        "%d %s %s %s: %s",
+                        object_idx,
+                        obj.objectType,
+                        obj.logicalName,
+                        attr_ind.attributeIndex,
+                        obj.getValues()[
+                            attr_ind.attributeIndex - 1])
                     object_idx += 1
             elif msg_format == 3:
                 # Used by Wiener Netze
                 # message contains timestamp + values, OBIS codes are only documented
-                # TODO: make the codes configurable, this specific arrangement is for Wiener Netze only according to issues 21 and 31
-                p =  GXDLMSPushSetup()
+                # TODO: make the codes configurable, this specific arrangement is for
+                # Wiener Netze only according to issues 21 and 31
+                p = GXDLMSPushSetup()
                 p.pushObjectList.append((GXDLMSClock(), GXDLMSCaptureObject(2, 0)))
                 p.pushObjectList.append((GXDLMSRegister("1.0.1.8.0.255"), GXDLMSCaptureObject(2, 0)))
                 p.pushObjectList.append((GXDLMSRegister("1.0.2.8.0.255"), GXDLMSCaptureObject(2, 0)))
@@ -147,7 +162,14 @@ class HdlcDlmsParser:
                 parsed_objects = self._p.pushObjectList
                 for index, (obj, attr_ind) in enumerate(parsed_objects):
                     self._client.updateValue(obj, attr_ind.attributeIndex, self._dlms_data.value[index])
-                    LOGGER.debug("%d %s %s %s: %s", index, obj.objectType, obj.logicalName, attr_ind.attributeIndex, obj.getValues()[attr_ind.attributeIndex - 1])
+                    LOGGER.debug(
+                        "%d %s %s %s: %s",
+                        index,
+                        obj.objectType,
+                        obj.logicalName,
+                        attr_ind.attributeIndex,
+                        obj.getValues()[
+                            attr_ind.attributeIndex - 1])
             else:
                 # Unknown message format
                 assert False

--- a/smartmeter_datacollector/smartmeter/iskraam550.py
+++ b/smartmeter_datacollector/smartmeter/iskraam550.py
@@ -72,7 +72,7 @@ ISKRA_AM550_COSEM_REGISTERS = [
 
 
 class IskraAM550(SerialHdlcDlmsMeter):
-    def __init__(self, port: str, baudrate: int = 115200, decryption_key: Optional[str] = None) -> None:
+    def __init__(self, port: str, provider: str, baudrate: int = 115200, decryption_key: Optional[str] = None) -> None:
         serial_config = SerialConfig(
             port=port,
             baudrate=baudrate,
@@ -88,7 +88,7 @@ class IskraAM550(SerialHdlcDlmsMeter):
         if decryption_key:
             LOGGER.warning("Using the Iskra AM550 meter with encrypted data has NOT BEEN TESTED yet!")
         try:
-            super().__init__(serial_config, cosem, decryption_key)
+            super().__init__(serial_config, cosem, provider, decryption_key)
         except ReaderError as ex:
             LOGGER.fatal("Unable to setup serial reader for Iskra AM550. '%s'", ex)
             raise MeterError("Failed setting up Iskra AM550.") from ex

--- a/smartmeter_datacollector/smartmeter/lge450.py
+++ b/smartmeter_datacollector/smartmeter/lge450.py
@@ -72,7 +72,7 @@ LGE450_COSEM_REGISTERS = [
 
 
 class LGE450(SerialHdlcDlmsMeter):
-    def __init__(self, port: str, baudrate: int = 2400, decryption_key: Optional[str] = None) -> None:
+    def __init__(self, port: str, provider: str, baudrate: int = 2400, decryption_key: Optional[str] = None) -> None:
         serial_config = SerialConfig(
             port=port,
             baudrate=baudrate,
@@ -86,7 +86,7 @@ class LGE450(SerialHdlcDlmsMeter):
             register_obis=LGE450_COSEM_REGISTERS
         )
         try:
-            super().__init__(serial_config, cosem, decryption_key)
+            super().__init__(serial_config, cosem, provider, decryption_key)
         except ReaderError as ex:
             LOGGER.fatal("Unable to setup serial reader for L+G E450. '%s'", ex)
             raise MeterError("Failed setting up L+G E450.") from ex

--- a/smartmeter_datacollector/smartmeter/meter.py
+++ b/smartmeter_datacollector/smartmeter/meter.py
@@ -37,7 +37,8 @@ class Meter(ABC):
 class SerialHdlcDlmsMeter(Meter):
     HDLC_FLAG = b"\x7e"
 
-    def __init__(self, serial_config: SerialConfig, cosem: Cosem, provider: str, decryption_key: Optional[str] = None) -> None:
+    def __init__(self, serial_config: SerialConfig, cosem: Cosem, provider: str,
+                 decryption_key: Optional[str] = None) -> None:
         super().__init__()
         self._parser = HdlcDlmsParser(cosem, provider, decryption_key)
         self._serial = SerialReader(serial_config, self._data_received)

--- a/smartmeter_datacollector/smartmeter/meter.py
+++ b/smartmeter_datacollector/smartmeter/meter.py
@@ -37,9 +37,9 @@ class Meter(ABC):
 class SerialHdlcDlmsMeter(Meter):
     HDLC_FLAG = b"\x7e"
 
-    def __init__(self, serial_config: SerialConfig, cosem: Cosem, decryption_key: Optional[str] = None) -> None:
+    def __init__(self, serial_config: SerialConfig, cosem: Cosem, provider: str, decryption_key: Optional[str] = None) -> None:
         super().__init__()
-        self._parser = HdlcDlmsParser(cosem, decryption_key)
+        self._parser = HdlcDlmsParser(cosem, provider, decryption_key)
         self._serial = SerialReader(serial_config, self._data_received)
 
     async def start(self) -> None:

--- a/tests/test_hdlc_dlms_parser.py
+++ b/tests/test_hdlc_dlms_parser.py
@@ -18,7 +18,7 @@ from .utils import *
 
 class TestHdlcParserUnencrypted:
     def test_extract_hdlc_data_framewise(self, unencrypted_valid_data_lg):
-        parser = HdlcDlmsParser(Cosem("", []))
+        parser = HdlcDlmsParser(Cosem("", []), provider = "EKZ")
 
         for frame in unencrypted_valid_data_lg:
             assert not parser.extract_data_from_hdlc_frames()
@@ -27,7 +27,7 @@ class TestHdlcParserUnencrypted:
         assert parser.extract_data_from_hdlc_frames()
 
     def test_extract_hdlc_data_in_halfframes(self, unencrypted_valid_data_lg):
-        parser = HdlcDlmsParser(Cosem("", []))
+        parser = HdlcDlmsParser(Cosem("", []), provider = "EKZ")
 
         for frame in unencrypted_valid_data_lg:
             frame: bytes
@@ -39,7 +39,7 @@ class TestHdlcParserUnencrypted:
         assert parser.extract_data_from_hdlc_frames()
 
     def test_extract_hdlc_data_with_random_prefix(self, unencrypted_valid_data_lg):
-        parser = HdlcDlmsParser(Cosem("", []))
+        parser = HdlcDlmsParser(Cosem("", []), provider = "EKZ")
         random.seed(123)
         prefix = bytes(random.getrandbits(8) for _ in range(32))
         parser.append_to_hdlc_buffer(prefix)
@@ -53,7 +53,7 @@ class TestHdlcParserUnencrypted:
 class TestDlmsParserUnencrypted:
     @pytest.fixture
     def valid_hdlc_buffer(self, cosem_config_lg, unencrypted_valid_data_lg) -> HdlcDlmsParser:
-        parser = HdlcDlmsParser(cosem_config_lg)
+        parser = HdlcDlmsParser(cosem_config_lg, provider = "EKZ")
         for frame in unencrypted_valid_data_lg:
             parser.append_to_hdlc_buffer(frame)
             parser.extract_data_from_hdlc_frames()
@@ -61,7 +61,7 @@ class TestDlmsParserUnencrypted:
 
     @pytest.fixture
     def invalid_hdlc_buffer(self, cosem_config_lg, unencrypted_invalid_data_lg) -> HdlcDlmsParser:
-        parser = HdlcDlmsParser(cosem_config_lg)
+        parser = HdlcDlmsParser(cosem_config_lg, provider = "EKZ")
         for frame in unencrypted_invalid_data_lg:
             parser.append_to_hdlc_buffer(frame)
             parser.extract_data_from_hdlc_frames()

--- a/tests/test_iskraam550.py
+++ b/tests/test_iskraam550.py
@@ -24,7 +24,7 @@ async def test_iskaam550_initialization(mocker: MockerFixture):
     test_bytes = bytes([1, 2, 3])
     serial_mock = mocker.patch("smartmeter_datacollector.smartmeter.meter.SerialReader",
                                autospec=True).return_value
-    meter = IskraAM550("/test/port")
+    meter = IskraAM550("/test/port", provider = "EKZ")
     serial_mock.start_and_listen.side_effect = meter._data_received(test_bytes)
     meter.register(observer)
     await meter.start()
@@ -41,7 +41,7 @@ async def test_iskraam550_parse_and_provide_unencrypted_data(mocker: MockerFixtu
     observer.mock_add_spec(['notify'])
     serial_mock = mocker.patch("smartmeter_datacollector.smartmeter.meter.SerialReader",
                                autospec=True).return_value
-    meter = IskraAM550("/test/port")
+    meter = IskraAM550("/test/port", provider = "EKZ")
     meter.register(observer)
 
     def data_received():

--- a/tests/test_lge450.py
+++ b/tests/test_lge450.py
@@ -24,7 +24,7 @@ async def test_lge450_initialization(mocker: MockerFixture):
     test_bytes = bytes([1, 2, 3])
     serial_mock = mocker.patch("smartmeter_datacollector.smartmeter.meter.SerialReader",
                                autospec=True).return_value
-    meter = LGE450("/test/port")
+    meter = LGE450("/test/port", provider = "EKZ")
     serial_mock.start_and_listen.side_effect = meter._data_received(test_bytes)
     meter.register(observer)
     await meter.start()
@@ -41,7 +41,7 @@ async def test_lge450_parse_and_provide_unencrypted_data(mocker: MockerFixture,
     observer.mock_add_spec(['notify'])
     serial_mock = mocker.patch("smartmeter_datacollector.smartmeter.meter.SerialReader",
                                autospec=True).return_value
-    meter = LGE450("/test/port")
+    meter = LGE450("/test/port", provider = "EKZ")
     meter.register(observer)
 
     def data_received():
@@ -78,7 +78,7 @@ async def test_lge450_do_not_provide_invalid_data(mocker: MockerFixture,
     observer.mock_add_spec(['notify'])
     serial_mock = mocker.patch("smartmeter_datacollector.smartmeter.meter.SerialReader",
                                autospec=True).return_value
-    meter = LGE450("/test/port")
+    meter = LGE450("/test/port", provider = "EKZ")
     meter.register(observer)
 
     def data_received():


### PR DESCRIPTION
Still need some refactoring especially when it comes to selecting the message format. Maybe also the `parse_to_dlms_objects` function should be split up by format? It seems to be quite big already and only will grow...

While it already works, I'm marking this as draft to see what still needs to be improved, layout wise.