### PR TITLE
Feature/#31 Parse data without push setup

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Prepare to build a Debian source package
         run: |
-          sudo apt-get -y install python3-all debhelper dh-python dh-systemd rename
+          sudo apt-get -y install python3-all debhelper dh-python rename
 
       - name: Build a Debian source package
         run: |

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: smartmeter-datacollector
 Maintainer: Supercomputing Systems AG <info@scs.ch>
 Section: python
 Priority: optional
-Build-Depends: python3-setuptools, python3-all, debhelper (>= 10), dh-systemd (>= 1.5)
+Build-Depends: python3-setuptools, python3-all, debhelper (>= 10)
 Standards-Version: 3.9.1
 Homepage: https://github.com/scs/smartmeter-datacollector
 

--- a/scripts/build_srcdeb.sh
+++ b/scripts/build_srcdeb.sh
@@ -27,7 +27,7 @@ echo "..done"
 
 # build the Python source distribution package
 echo -n "Building Python source distribution package.."
-pipenv run build > /dev/null 2>&1
+pipenv run build
 echo "..done"
 
 # prepare the output directory
@@ -58,7 +58,7 @@ echo "..done"
 # build the Debian source package
 echo -n "Building the Debian package (${BUILD_TYPE}).."
 cd ${PACKAGE_DIR}/
-dpkg-buildpackage --build=${BUILD_TYPE} -rfakeroot -sa -us -uc > /dev/null 2>&1
+dpkg-buildpackage --build=${BUILD_TYPE} -rfakeroot -sa -us -uc
 echo "..done"
 
 cd ${CWD}

--- a/smartmeter_datacollector/smartmeter/cosem.py
+++ b/smartmeter_datacollector/smartmeter/cosem.py
@@ -14,31 +14,91 @@ from typing import Any, Dict, List, Optional
 from gurux_dlms import GXDateTime
 from gurux_dlms.objects import GXDLMSClock, GXDLMSData
 
-from .meter_data import MeterDataPointType
+from .meter_data import MeterDataPointType, MeterDataPointTypes
+from .obis import OBISCode
 
 LOGGER = logging.getLogger("smartmeter")
-
-OBIS_DEFAULT_IDS = [
-    "0.0.42.0.0.255",
-    "0.0.96.1.0.255",
-    "0.0.96.2.0.255",
-    "0.0.96.3.0.255",
-    "0.0.96.4.0.255",
-    "0.0.96.5.0.255"
-]
-OBIS_DEFAULT_CLOCK = "0.0.1.0.0.255"
-COSEM_OBJECT_DETECT_ATTEMPTS = 3
 
 
 @dataclass
 class RegisterCosem:
-    obis: str
+    obis: OBISCode
     data_point_type: MeterDataPointType
     scaling: float = 1.0
 
 
+OBIS_DEFAULT_IDS = [
+    OBISCode(0, 0, 42, 0, 0),
+    OBISCode(0, 0, 96, 1, 0),
+    OBISCode(0, 0, 96, 1, 1),
+    OBISCode(0, 0, 96, 1, 2),
+    OBISCode(0, 0, 96, 1, 3),
+    OBISCode(0, 0, 96, 1, 4),
+    OBISCode(0, 0, 96, 1, 5)
+]
+OBIS_DEFAULT_CLOCK = OBISCode(0, 0, 1, 0, 0)
+COSEM_OBJECT_DETECT_ATTEMPTS = 3
+
+
+DEFAULT_COSEM_REGISTERS = [
+    RegisterCosem(OBISCode(1, 0, 1, 7, 0), MeterDataPointTypes.ACTIVE_POWER_P.value),
+    RegisterCosem(OBISCode(1, 0, 2, 7, 0), MeterDataPointTypes.ACTIVE_POWER_N.value),
+    RegisterCosem(OBISCode(1, 0, 3, 7, 0), MeterDataPointTypes.REACTIVE_POWER_P.value),
+    RegisterCosem(OBISCode(1, 0, 4, 7, 0), MeterDataPointTypes.REACTIVE_POWER_N.value),
+
+    RegisterCosem(OBISCode(1, 0, 13, 7, 0), MeterDataPointTypes.POWER_FACTOR.value, 0.001),
+    RegisterCosem(OBISCode(1, 0, 14, 7, 0), MeterDataPointTypes.NET_FREQUENCY.value),
+
+    RegisterCosem(OBISCode(1, 0, 21, 7, 0), MeterDataPointTypes.ACTIVE_POWER_P_L1.value),
+    RegisterCosem(OBISCode(1, 0, 22, 7, 0), MeterDataPointTypes.ACTIVE_POWER_N_L1.value),
+    RegisterCosem(OBISCode(1, 0, 23, 7, 0), MeterDataPointTypes.REACTIVE_POWER_P_L1.value),
+    RegisterCosem(OBISCode(1, 0, 24, 7, 0), MeterDataPointTypes.REACTIVE_POWER_N_L1.value),
+
+    RegisterCosem(OBISCode(1, 0, 31, 7, 0), MeterDataPointTypes.CURRENT_L1.value),
+    RegisterCosem(OBISCode(1, 0, 32, 7, 0), MeterDataPointTypes.VOLTAGE_L1.value),
+
+    RegisterCosem(OBISCode(1, 0, 41, 7, 0), MeterDataPointTypes.ACTIVE_POWER_P_L2.value),
+    RegisterCosem(OBISCode(1, 0, 42, 7, 0), MeterDataPointTypes.ACTIVE_POWER_N_L2.value),
+    RegisterCosem(OBISCode(1, 0, 43, 7, 0), MeterDataPointTypes.REACTIVE_POWER_P_L2.value),
+    RegisterCosem(OBISCode(1, 0, 44, 7, 0), MeterDataPointTypes.REACTIVE_POWER_N_L2.value),
+
+    RegisterCosem(OBISCode(1, 0, 51, 7, 0), MeterDataPointTypes.CURRENT_L2.value),
+    RegisterCosem(OBISCode(1, 0, 52, 7, 0), MeterDataPointTypes.VOLTAGE_L2.value),
+
+    RegisterCosem(OBISCode(1, 0, 61, 7, 0), MeterDataPointTypes.ACTIVE_POWER_P_L3.value),
+    RegisterCosem(OBISCode(1, 0, 62, 7, 0), MeterDataPointTypes.ACTIVE_POWER_N_L3.value),
+    RegisterCosem(OBISCode(1, 0, 63, 7, 0), MeterDataPointTypes.REACTIVE_POWER_P_L3.value),
+    RegisterCosem(OBISCode(1, 0, 64, 7, 0), MeterDataPointTypes.REACTIVE_POWER_N_L3.value),
+
+    RegisterCosem(OBISCode(1, 0, 71, 7, 0), MeterDataPointTypes.CURRENT_L3.value),
+    RegisterCosem(OBISCode(1, 0, 72, 7, 0), MeterDataPointTypes.VOLTAGE_L3.value),
+
+    RegisterCosem(OBISCode(1, 0, 81, 7, 40), MeterDataPointTypes.ANGLE_UI_L1.value),
+    RegisterCosem(OBISCode(1, 0, 81, 7, 51), MeterDataPointTypes.ANGLE_UI_L2.value),
+    RegisterCosem(OBISCode(1, 0, 81, 7, 62), MeterDataPointTypes.ANGLE_UI_L3.value),
+
+    RegisterCosem(OBISCode(1, 0, 1, 8, 0), MeterDataPointTypes.ACTIVE_ENERGY_P.value),
+    RegisterCosem(OBISCode(1, 0, 1, 8, 1), MeterDataPointTypes.ACTIVE_ENERGY_P_T1.value),
+    RegisterCosem(OBISCode(1, 0, 1, 8, 2), MeterDataPointTypes.ACTIVE_ENERGY_P_T2.value),
+    RegisterCosem(OBISCode(1, 0, 2, 8, 0), MeterDataPointTypes.ACTIVE_ENERGY_N.value),
+    RegisterCosem(OBISCode(1, 0, 2, 8, 1), MeterDataPointTypes.ACTIVE_ENERGY_N_T1.value),
+    RegisterCosem(OBISCode(1, 0, 2, 8, 2), MeterDataPointTypes.ACTIVE_ENERGY_N_T2.value),
+    RegisterCosem(OBISCode(1, 0, 3, 8, 0), MeterDataPointTypes.REACTIVE_ENERGY_P.value),
+    RegisterCosem(OBISCode(1, 0, 3, 8, 1), MeterDataPointTypes.REACTIVE_ENERGY_P_T1.value),
+    RegisterCosem(OBISCode(1, 0, 3, 8, 2), MeterDataPointTypes.REACTIVE_ENERGY_P_T2.value),
+    RegisterCosem(OBISCode(1, 0, 4, 8, 0), MeterDataPointTypes.REACTIVE_ENERGY_N.value),
+    RegisterCosem(OBISCode(1, 0, 4, 8, 1), MeterDataPointTypes.REACTIVE_ENERGY_N_T1.value),
+    RegisterCosem(OBISCode(1, 0, 4, 8, 2), MeterDataPointTypes.REACTIVE_ENERGY_N_T2.value),
+
+    RegisterCosem(OBISCode(1, 0, 5, 8, 0), MeterDataPointTypes.REACTIVE_ENERGY_Q1.value),
+    RegisterCosem(OBISCode(1, 0, 6, 8, 0), MeterDataPointTypes.REACTIVE_ENERGY_Q2.value),
+    RegisterCosem(OBISCode(1, 0, 7, 8, 0), MeterDataPointTypes.REACTIVE_ENERGY_Q3.value),
+    RegisterCosem(OBISCode(1, 0, 8, 8, 0), MeterDataPointTypes.REACTIVE_ENERGY_Q4.value),
+]
+
+
 class Cosem:
-    def __init__(self, fallback_id: str, register_obis: List[RegisterCosem]) -> None:
+    def __init__(self, fallback_id: str, register_obis: List[RegisterCosem] = DEFAULT_COSEM_REGISTERS) -> None:
         self._id: Optional[str] = None
         if not fallback_id:
             fallback_id = str(uuid.uuid1())
@@ -47,11 +107,11 @@ class Cosem:
         self._register_obis = {r.obis: r for r in register_obis}
         self._id_detect_countdown = COSEM_OBJECT_DETECT_ATTEMPTS
 
-    def retrieve_id(self, dlms_objects: Dict[str, Any]) -> str:
+    def retrieve_id(self, dlms_objects: Dict[OBISCode, Any]) -> str:
         if self._id:
             return self._id
 
-        id_obis = self._find_id_obis(dlms_objects)
+        id_obis = self._find_obis_of_id(dlms_objects)
         if not id_obis:
             LOGGER.debug("Unable to find ID object. Using fallback ID %s.", self._fallback_id)
             self._trigger_id_detect_counter()
@@ -73,20 +133,20 @@ class Cosem:
         LOGGER.debug("ID %s found with OBIS code %s.", meter_id, id_obis)
         return meter_id
 
-    def retrieve_timestamp(self, dlms_objects: Dict[str, Any]) -> datetime:
+    def retrieve_timestamp(self, dlms_objects: Dict[OBISCode, Any]) -> datetime:
         clock_obj = dlms_objects.get(OBIS_DEFAULT_CLOCK, None)
         if clock_obj and isinstance(clock_obj, GXDLMSClock):
             timestamp = self._extract_datetime(clock_obj)
             if timestamp:
                 return timestamp
 
-            LOGGER.warning("Unable to parse timestamp from %s. Using system time.", OBIS_DEFAULT_CLOCK)
+            LOGGER.warning("Unable to parse timestamp from %s. Using system time.", str(OBIS_DEFAULT_CLOCK))
         else:
-            LOGGER.debug("No clock object found at %s. Using system time.", OBIS_DEFAULT_CLOCK)
+            LOGGER.debug("No clock object found at %s. Using system time.", str(OBIS_DEFAULT_CLOCK))
 
         return datetime.utcnow()
 
-    def get_register(self, obis: str) -> Optional[RegisterCosem]:
+    def get_register(self, obis: OBISCode) -> Optional[RegisterCosem]:
         return self._register_obis.get(obis, None)
 
     def _trigger_id_detect_counter(self):
@@ -97,7 +157,7 @@ class Cosem:
             self._id = self._fallback_id
 
     @staticmethod
-    def _find_id_obis(dlms_objects: Dict[str, Any]) -> Optional[str]:
+    def _find_obis_of_id(dlms_objects: Dict[OBISCode, Any]) -> Optional[OBISCode]:
         for default_obis in OBIS_DEFAULT_IDS:
             if default_obis in dlms_objects:
                 return default_obis

--- a/smartmeter_datacollector/smartmeter/hdlc_dlms_parser.py
+++ b/smartmeter_datacollector/smartmeter/hdlc_dlms_parser.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from gurux_dlms import GXByteBuffer, GXDLMSClient, GXReplyData
 from gurux_dlms.enums import InterfaceType, ObjectType, Security
-from gurux_dlms.objects import GXDLMSData, GXDLMSObject, GXDLMSRegister, GXDLMSPushSetup, GXDLMSClock, GXDLMSCaptureObject
+from gurux_dlms.objects import (GXDLMSCaptureObject, GXDLMSClock, GXDLMSData, GXDLMSObject, GXDLMSPushSetup,
+                                GXDLMSRegister)
 from gurux_dlms.secure import GXDLMSSecureClient
 
 from .cosem import Cosem
@@ -163,7 +164,8 @@ class HdlcDlmsParser:
 
     @staticmethod
     def extract_values(data: List[Any]) -> List[Any]:
-        return list(filter(lambda d: isinstance(d, int) or not (isinstance(d, bytearray) and HdlcDlmsParser.is_obis(d)), data))
+        return list(filter(lambda d: isinstance(d, int) or not (
+            isinstance(d, bytearray) and HdlcDlmsParser.is_obis(d)), data))
 
     @staticmethod
     def is_obis(value: bytearray) -> bool:

--- a/smartmeter_datacollector/smartmeter/iskraam550.py
+++ b/smartmeter_datacollector/smartmeter/iskraam550.py
@@ -10,65 +10,12 @@ from typing import Optional
 
 import serial
 
-from .cosem import Cosem, RegisterCosem
+from .cosem import Cosem
 from .meter import MeterError, SerialHdlcDlmsMeter
-from .meter_data import MeterDataPointTypes
 from .reader import ReaderError
 from .serial_reader import SerialConfig
 
 LOGGER = logging.getLogger("smartmeter")
-
-ISKRA_AM550_COSEM_REGISTERS = [
-    RegisterCosem("1.1.1.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P.value),
-    RegisterCosem("1.1.2.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N.value),
-    RegisterCosem("1.1.3.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P.value),
-    RegisterCosem("1.1.4.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N.value),
-
-    RegisterCosem("1.0.13.7.0.255", MeterDataPointTypes.POWER_FACTOR.value, 0.001),
-    RegisterCosem("1.0.14.7.0.255", MeterDataPointTypes.NET_FREQUENCY.value),
-
-    RegisterCosem("1.0.21.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P_L1.value),
-    RegisterCosem("1.0.22.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N_L1.value),
-    RegisterCosem("1.0.23.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P_L1.value),
-    RegisterCosem("1.0.24.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N_L1.value),
-
-    RegisterCosem("1.0.31.7.0.255", MeterDataPointTypes.CURRENT_L1.value),
-    RegisterCosem("1.0.32.7.0.255", MeterDataPointTypes.VOLTAGE_L1.value),
-
-    RegisterCosem("1.0.41.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P_L2.value),
-    RegisterCosem("1.0.42.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N_L2.value),
-    RegisterCosem("1.0.43.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P_L2.value),
-    RegisterCosem("1.0.44.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N_L2.value),
-
-    RegisterCosem("1.0.51.7.0.255", MeterDataPointTypes.CURRENT_L2.value),
-    RegisterCosem("1.0.52.7.0.255", MeterDataPointTypes.VOLTAGE_L2.value),
-
-    RegisterCosem("1.0.61.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P_L3.value),
-    RegisterCosem("1.0.62.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N_L3.value),
-    RegisterCosem("1.0.63.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P_L3.value),
-    RegisterCosem("1.0.64.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N_L3.value),
-
-    RegisterCosem("1.0.71.7.0.255", MeterDataPointTypes.CURRENT_L3.value),
-    RegisterCosem("1.0.72.7.0.255", MeterDataPointTypes.VOLTAGE_L3.value),
-
-    RegisterCosem("1.0.81.7.40.255", MeterDataPointTypes.ANGLE_UI_L1.value),
-    RegisterCosem("1.0.81.7.51.255", MeterDataPointTypes.ANGLE_UI_L2.value),
-    RegisterCosem("1.0.81.7.62.255", MeterDataPointTypes.ANGLE_UI_L3.value),
-
-    RegisterCosem("1.1.1.8.0.255", MeterDataPointTypes.ACTIVE_ENERGY_P.value),
-    RegisterCosem("1.1.1.8.1.255", MeterDataPointTypes.ACTIVE_ENERGY_P_T1.value),
-    RegisterCosem("1.1.1.8.2.255", MeterDataPointTypes.ACTIVE_ENERGY_P_T2.value),
-    RegisterCosem("1.1.2.8.0.255", MeterDataPointTypes.ACTIVE_ENERGY_N.value),
-    RegisterCosem("1.1.2.8.1.255", MeterDataPointTypes.ACTIVE_ENERGY_N_T1.value),
-    RegisterCosem("1.1.2.8.2.255", MeterDataPointTypes.ACTIVE_ENERGY_N_T2.value),
-    RegisterCosem("1.1.3.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_P.value),
-    RegisterCosem("1.1.4.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_N.value),
-
-    RegisterCosem("1.1.5.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q1.value),
-    RegisterCosem("1.1.6.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q2.value),
-    RegisterCosem("1.1.7.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q3.value),
-    RegisterCosem("1.1.8.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q4.value),
-]
 
 
 class IskraAM550(SerialHdlcDlmsMeter):
@@ -81,10 +28,7 @@ class IskraAM550(SerialHdlcDlmsMeter):
             stop_bits=serial.STOPBITS_ONE,
             termination=IskraAM550.HDLC_FLAG
         )
-        cosem = Cosem(
-            fallback_id=port,
-            register_obis=ISKRA_AM550_COSEM_REGISTERS
-        )
+        cosem = Cosem(fallback_id=port)
         if decryption_key:
             LOGGER.warning("Using the Iskra AM550 meter with encrypted data has NOT BEEN TESTED yet!")
         try:

--- a/smartmeter_datacollector/smartmeter/lge450.py
+++ b/smartmeter_datacollector/smartmeter/lge450.py
@@ -10,77 +10,12 @@ from typing import Optional
 
 import serial
 
-from .cosem import Cosem, RegisterCosem
+from .cosem import Cosem
 from .meter import MeterError, SerialHdlcDlmsMeter
-from .meter_data import MeterDataPointTypes
 from .reader import ReaderError
 from .serial_reader import SerialConfig
 
 LOGGER = logging.getLogger("smartmeter")
-
-LGE450_COSEM_REGISTERS = [
-    RegisterCosem("1.0.1.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P.value),
-    RegisterCosem("1.0.2.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N.value),
-    RegisterCosem("1.0.3.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P.value),
-    RegisterCosem("1.0.4.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N.value),
-
-    RegisterCosem("1.0.13.7.0.255", MeterDataPointTypes.POWER_FACTOR.value, 0.001),
-    RegisterCosem("1.0.14.7.0.255", MeterDataPointTypes.NET_FREQUENCY.value),
-
-    RegisterCosem("1.0.21.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P_L1.value),
-    RegisterCosem("1.0.22.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N_L1.value),
-    RegisterCosem("1.0.23.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P_L1.value),
-    RegisterCosem("1.0.24.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N_L1.value),
-
-    RegisterCosem("1.0.31.7.0.255", MeterDataPointTypes.CURRENT_L1.value),
-    RegisterCosem("1.0.32.7.0.255", MeterDataPointTypes.VOLTAGE_L1.value),
-
-    RegisterCosem("1.0.41.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P_L2.value),
-    RegisterCosem("1.0.42.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N_L2.value),
-    RegisterCosem("1.0.43.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P_L2.value),
-    RegisterCosem("1.0.44.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N_L2.value),
-
-    RegisterCosem("1.0.51.7.0.255", MeterDataPointTypes.CURRENT_L2.value),
-    RegisterCosem("1.0.52.7.0.255", MeterDataPointTypes.VOLTAGE_L2.value),
-
-    RegisterCosem("1.0.61.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P_L3.value),
-    RegisterCosem("1.0.62.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N_L3.value),
-    RegisterCosem("1.0.63.7.0.255", MeterDataPointTypes.REACTIVE_POWER_P_L3.value),
-    RegisterCosem("1.0.64.7.0.255", MeterDataPointTypes.REACTIVE_POWER_N_L3.value),
-
-    RegisterCosem("1.0.71.7.0.255", MeterDataPointTypes.CURRENT_L3.value),
-    RegisterCosem("1.0.72.7.0.255", MeterDataPointTypes.VOLTAGE_L3.value),
-
-    RegisterCosem("1.0.81.7.40.255", MeterDataPointTypes.ANGLE_UI_L1.value),
-    RegisterCosem("1.0.81.7.51.255", MeterDataPointTypes.ANGLE_UI_L2.value),
-    RegisterCosem("1.0.81.7.62.255", MeterDataPointTypes.ANGLE_UI_L3.value),
-
-    RegisterCosem("1.0.1.8.0.255", MeterDataPointTypes.ACTIVE_ENERGY_P.value),
-    RegisterCosem("1.1.1.8.0.255", MeterDataPointTypes.ACTIVE_ENERGY_P.value),
-    RegisterCosem("1.0.1.8.1.255", MeterDataPointTypes.ACTIVE_ENERGY_P_T1.value),
-    RegisterCosem("1.1.1.8.1.255", MeterDataPointTypes.ACTIVE_ENERGY_P_T1.value),
-    RegisterCosem("1.0.1.8.2.255", MeterDataPointTypes.ACTIVE_ENERGY_P_T2.value),
-    RegisterCosem("1.1.1.8.2.255", MeterDataPointTypes.ACTIVE_ENERGY_P_T2.value),
-    RegisterCosem("1.0.2.8.0.255", MeterDataPointTypes.ACTIVE_ENERGY_N.value),
-    RegisterCosem("1.1.2.8.0.255", MeterDataPointTypes.ACTIVE_ENERGY_N.value),
-    RegisterCosem("1.0.2.8.1.255", MeterDataPointTypes.ACTIVE_ENERGY_N_T1.value),
-    RegisterCosem("1.1.2.8.1.255", MeterDataPointTypes.ACTIVE_ENERGY_N_T1.value),
-    RegisterCosem("1.0.2.8.2.255", MeterDataPointTypes.ACTIVE_ENERGY_N_T2.value),
-    RegisterCosem("1.1.2.8.2.255", MeterDataPointTypes.ACTIVE_ENERGY_N_T2.value),
-    RegisterCosem("1.0.3.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_P.value),
-    RegisterCosem("1.1.3.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_P.value),
-    RegisterCosem("1.0.3.8.1.255", MeterDataPointTypes.REACTIVE_ENERGY_P_T1.value),
-    RegisterCosem("1.0.3.8.2.255", MeterDataPointTypes.REACTIVE_ENERGY_P_T2.value),
-    RegisterCosem("1.0.4.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_N.value),
-    RegisterCosem("1.1.4.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_N.value),
-    RegisterCosem("1.0.4.8.1.255", MeterDataPointTypes.REACTIVE_ENERGY_N_T1.value),
-    RegisterCosem("1.0.4.8.2.255", MeterDataPointTypes.REACTIVE_ENERGY_N_T2.value),
-
-    RegisterCosem("1.1.5.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q1.value),
-    RegisterCosem("1.1.6.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q2.value),
-    RegisterCosem("1.1.7.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q3.value),
-    RegisterCosem("1.1.8.8.0.255", MeterDataPointTypes.REACTIVE_ENERGY_Q4.value),
-]
 
 
 class LGE450(SerialHdlcDlmsMeter):
@@ -93,10 +28,7 @@ class LGE450(SerialHdlcDlmsMeter):
             stop_bits=serial.STOPBITS_ONE,
             termination=LGE450.HDLC_FLAG
         )
-        cosem = Cosem(
-            fallback_id=port,
-            register_obis=LGE450_COSEM_REGISTERS
-        )
+        cosem = Cosem(fallback_id=port)
         try:
             super().__init__(serial_config, cosem, decryption_key)
         except ReaderError as ex:

--- a/smartmeter_datacollector/smartmeter/obis.py
+++ b/smartmeter_datacollector/smartmeter/obis.py
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2022 Supercomputing Systems AG
+# This file is part of smartmeter-datacollector.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+# See LICENSES/README.md for more information.
+#
+import re
+from dataclasses import dataclass, field
+from typing import ClassVar, Union
+
+REGEX = r"^(\d{1,3})\W(\d{1,3})\W(\d{1,3})\W(\d{1,3})\W(\d{1,3})\W(\d{1,3})$"
+
+
+@dataclass(frozen=True)
+class OBISCode:
+    PATTERN: ClassVar[re.Pattern] = re.compile(REGEX)
+
+    # pylint: disable=invalid-name
+    a: int
+    b: int = field(compare=False)
+    c: int
+    d: int
+    e: int
+    f: int = field(default=255, compare=False)
+
+    def __str__(self) -> str:
+        return f"{self.a}-{self.b}:{self.c}.{self.d}.{self.e}*{self.f}"
+
+    def to_gurux_str(self) -> str:
+        return f"{self.a}.{self.b}.{self.c}.{self.d}.{self.e}.{self.f}"
+
+    def is_same_type(self, other: 'OBISCode') -> bool:
+        """Compares only A, C, D, E parts of an OBIS code."""
+        return (self.a == other.a and
+                self.b == other.b and
+                self.c == other.c and
+                self.d == other.d)
+
+    @classmethod
+    def from_string(cls, obis_string: str) -> 'OBISCode':
+        match = cls.PATTERN.match(obis_string)
+        if not match:
+            raise ValueError("Invalid OBIS string \"%s\".", obis_string)
+        groups = match.groups()
+        return cls(*(int(g) for g in groups))
+
+    @classmethod
+    def from_bytes(cls, obis_bytes: Union[bytes, bytearray]) -> 'OBISCode':
+        if not cls.is_obis(obis_bytes):
+            raise ValueError("Invalid OBIS bytes.")
+        return cls(*obis_bytes)
+
+    @staticmethod
+    def is_obis(data: Union[bytes, bytearray]) -> bool:
+        return (len(data) == 6 and
+                data[0] < 10 and
+                data[1] <= 64 and
+                data[3] < 128)

--- a/tests/test_hdlc_dlms_parser.py
+++ b/tests/test_hdlc_dlms_parser.py
@@ -55,13 +55,12 @@ class TestDlmsParserUnencrypted:
         parser = prepare_parser(unencrypted_valid_data_lg, cosem_config_lg)
         dlms_objects = parser.parse_to_dlms_objects()
 
-        assert isinstance(dlms_objects, dict)
-        assert len(dlms_objects) == 15
+        assert isinstance(dlms_objects, list)
+        assert len(dlms_objects) == 16
         obis_pattern = re.compile(r"(\d+\.){5}\d+")
-        for key, value in dlms_objects.items():
-            assert isinstance(key, str)
-            assert re.match(obis_pattern, key)
-            assert isinstance(value, GXDLMSObject)
+        for obj in dlms_objects:
+            assert isinstance(obj, GXDLMSObject)
+            assert re.match(obis_pattern, str(obj.logicalName))
 
     def test_parse_dlms_to_meter_data(self, unencrypted_valid_data_lg: List[bytes], cosem_config_lg: Cosem):
         parser = prepare_parser(unencrypted_valid_data_lg, cosem_config_lg)
@@ -98,10 +97,9 @@ class TestDlmsParserEncrypted:
         parser = prepare_parser(encrypted_data_no_pushlist_lg, cosem_config_lg, "F08660A6C19D2048556BF623AB0257E6")
         dlms_objects = parser.parse_to_dlms_objects()
 
-        assert isinstance(dlms_objects, dict)
+        assert isinstance(dlms_objects, list)
         assert len(dlms_objects) == 17
         obis_pattern = re.compile(r"(\d+\.){5}\d+")
-        for key, value in dlms_objects.items():
-            assert isinstance(key, str)
-            assert re.match(obis_pattern, key)
-            assert isinstance(value, GXDLMSObject)
+        for obj in dlms_objects:
+            assert isinstance(obj, GXDLMSObject)
+            assert re.match(obis_pattern, str(obj.logicalName))

--- a/tests/test_hdlc_dlms_parser.py
+++ b/tests/test_hdlc_dlms_parser.py
@@ -76,6 +76,14 @@ class TestDlmsParserUnencrypted:
         assert all(data.source == "LGZ1030655933512" for data in meter_data)
         assert all(data.timestamp.strftime(r"%m/%d/%y %H:%M:%S") == "07/06/21 14:58:18" for data in meter_data)
 
+    def test_parse_dlms_to_meter_data2(self, unencrypted_valid_data_lg2: List[bytes], cosem_config_lg: Cosem):
+        parser = prepare_parser(unencrypted_valid_data_lg2, cosem_config_lg)
+        dlms_objects = parser.parse_to_dlms_objects()
+        meter_data = parser.convert_dlms_bundle_to_reader_data(dlms_objects)
+
+        assert isinstance(meter_data, list)
+        assert len(meter_data) == 2
+
     def test_ignore_not_parsable_data_to_meter_data(self, unencrypted_invalid_data_lg: List[bytes], cosem_config_lg: Cosem):
         parser = prepare_parser(unencrypted_invalid_data_lg, cosem_config_lg)
         dlms_objects = parser.parse_to_dlms_objects()
@@ -83,3 +91,17 @@ class TestDlmsParserUnencrypted:
 
         assert isinstance(meter_data, list)
         assert len(meter_data) == 2
+
+
+class TestDlmsParserEncrypted:
+    def test_hdlc_to_dlms_objects_without_pushlist(self, encrypted_data_no_pushlist_lg: List[bytes], cosem_config_lg: Cosem):
+        parser = prepare_parser(encrypted_data_no_pushlist_lg, cosem_config_lg, "F08660A6C19D2048556BF623AB0257E6")
+        dlms_objects = parser.parse_to_dlms_objects()
+
+        assert isinstance(dlms_objects, dict)
+        assert len(dlms_objects) == 17
+        obis_pattern = re.compile(r"(\d+\.){5}\d+")
+        for key, value in dlms_objects.items():
+            assert isinstance(key, str)
+            assert re.match(obis_pattern, key)
+            assert isinstance(value, GXDLMSObject)

--- a/tests/test_hdlc_dlms_parser.py
+++ b/tests/test_hdlc_dlms_parser.py
@@ -17,7 +17,7 @@ from .utils import *
 
 
 class TestHdlcParserUnencrypted:
-    def test_extract_hdlc_data_framewise(self, unencrypted_valid_data_lg):
+    def test_extract_hdlc_data_framewise(self, unencrypted_valid_data_lg: List[bytes]):
         parser = HdlcDlmsParser(Cosem("", []))
 
         for frame in unencrypted_valid_data_lg:
@@ -26,7 +26,7 @@ class TestHdlcParserUnencrypted:
 
         assert parser.extract_data_from_hdlc_frames()
 
-    def test_extract_hdlc_data_in_halfframes(self, unencrypted_valid_data_lg):
+    def test_extract_hdlc_data_in_halfframes(self, unencrypted_valid_data_lg: List[bytes]):
         parser = HdlcDlmsParser(Cosem("", []))
 
         for frame in unencrypted_valid_data_lg:
@@ -38,7 +38,7 @@ class TestHdlcParserUnencrypted:
 
         assert parser.extract_data_from_hdlc_frames()
 
-    def test_extract_hdlc_data_with_random_prefix(self, unencrypted_valid_data_lg):
+    def test_extract_hdlc_data_with_random_prefix(self, unencrypted_valid_data_lg: List[bytes]):
         parser = HdlcDlmsParser(Cosem("", []))
         random.seed(123)
         prefix = bytes(random.getrandbits(8) for _ in range(32))
@@ -51,24 +51,9 @@ class TestHdlcParserUnencrypted:
 
 
 class TestDlmsParserUnencrypted:
-    @pytest.fixture
-    def valid_hdlc_buffer(self, cosem_config_lg, unencrypted_valid_data_lg) -> HdlcDlmsParser:
-        parser = HdlcDlmsParser(cosem_config_lg)
-        for frame in unencrypted_valid_data_lg:
-            parser.append_to_hdlc_buffer(frame)
-            parser.extract_data_from_hdlc_frames()
-        return parser
-
-    @pytest.fixture
-    def invalid_hdlc_buffer(self, cosem_config_lg, unencrypted_invalid_data_lg) -> HdlcDlmsParser:
-        parser = HdlcDlmsParser(cosem_config_lg)
-        for frame in unencrypted_invalid_data_lg:
-            parser.append_to_hdlc_buffer(frame)
-            parser.extract_data_from_hdlc_frames()
-        return parser
-
-    def test_parse_hdlc_to_dlms_objects(self, valid_hdlc_buffer: HdlcDlmsParser):
-        dlms_objects = valid_hdlc_buffer.parse_to_dlms_objects()
+    def test_hdlc_to_dlms_objects_with_pushlist(self, unencrypted_valid_data_lg: List[bytes], cosem_config_lg: Cosem):
+        parser = prepare_parser(unencrypted_valid_data_lg, cosem_config_lg)
+        dlms_objects = parser.parse_to_dlms_objects()
 
         assert isinstance(dlms_objects, dict)
         assert len(dlms_objects) == 15
@@ -78,9 +63,11 @@ class TestDlmsParserUnencrypted:
             assert re.match(obis_pattern, key)
             assert isinstance(value, GXDLMSObject)
 
-    def test_parse_dlms_to_meter_data(self, valid_hdlc_buffer: HdlcDlmsParser):
-        dlms_objects = valid_hdlc_buffer.parse_to_dlms_objects()
-        meter_data = valid_hdlc_buffer.convert_dlms_bundle_to_reader_data(dlms_objects)
+    def test_parse_dlms_to_meter_data(self, unencrypted_valid_data_lg: List[bytes], cosem_config_lg: Cosem):
+        parser = prepare_parser(unencrypted_valid_data_lg, cosem_config_lg)
+        dlms_objects = parser.parse_to_dlms_objects()
+        meter_data = parser.convert_dlms_bundle_to_reader_data(dlms_objects)
+
         assert isinstance(meter_data, list)
         assert len(meter_data) == 2
         assert any(data.type == MeterDataPointTypes.ACTIVE_POWER_P.value for data in meter_data)
@@ -89,8 +76,10 @@ class TestDlmsParserUnencrypted:
         assert all(data.source == "LGZ1030655933512" for data in meter_data)
         assert all(data.timestamp.strftime(r"%m/%d/%y %H:%M:%S") == "07/06/21 14:58:18" for data in meter_data)
 
-    def test_parse_not_parsable_data_to_meter_data(self, invalid_hdlc_buffer: HdlcDlmsParser):
-        dlms_objects = invalid_hdlc_buffer.parse_to_dlms_objects()
-        meter_data = invalid_hdlc_buffer.convert_dlms_bundle_to_reader_data(dlms_objects)
+    def test_ignore_not_parsable_data_to_meter_data(self, unencrypted_invalid_data_lg: List[bytes], cosem_config_lg: Cosem):
+        parser = prepare_parser(unencrypted_invalid_data_lg, cosem_config_lg)
+        dlms_objects = parser.parse_to_dlms_objects()
+        meter_data = parser.convert_dlms_bundle_to_reader_data(dlms_objects)
+
         assert isinstance(meter_data, list)
         assert len(meter_data) == 2

--- a/tests/test_obis.py
+++ b/tests/test_obis.py
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2022 Supercomputing Systems AG
+# This file is part of smartmeter-datacollector.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+# See LICENSES/README.md for more information.
+#
+from smartmeter_datacollector.smartmeter.obis import OBISCode
+
+
+def test_create_from_gurux_string():
+    obis_string = "1.0.1.7.0.255"
+    obis = OBISCode.from_string(obis_string)
+    assert obis
+    assert obis.a == 1
+    assert obis.b == 0
+    assert obis.c == 1
+    assert obis.d == 7
+    assert obis.e == 0
+    assert obis.f == 255
+
+
+def test_create_from_IEC_62056_string():
+    obis_string = "1-0:1.7.0*255"
+    obis = OBISCode.from_string(obis_string)
+    assert obis
+    assert obis.a == 1
+    assert obis.b == 0
+    assert obis.c == 1
+    assert obis.d == 7
+    assert obis.e == 0
+    assert obis.f == 255
+
+
+def test_create_from_bytes():
+    obis_bytes = bytes.fromhex("01 01 01 08 02 FF")
+    obis = OBISCode.from_bytes(obis_bytes)
+    assert obis
+    assert obis.a == 1
+    assert obis.b == 1
+    assert obis.c == 1
+    assert obis.d == 8
+    assert obis.e == 2
+    assert obis.f == 255
+
+
+def test_to_IEC62056_string():
+    obis = OBISCode(1, 0, 1, 7, 0, 255)
+    assert str(obis) == "1-0:1.7.0*255"
+
+
+def test_to_gurux_string():
+    obis = OBISCode(1, 0, 1, 7, 0, 255)
+    assert obis.to_gurux_str() == "1.0.1.7.0.255"
+
+
+def test_only_compare_relevant_parts():
+    obis = OBISCode(1, 0, 1, 7, 0, 255)
+    assert obis == OBISCode(1, 1, 1, 7, 0, 255)
+    assert obis == OBISCode(1, 0, 1, 7, 0, 128)
+    assert obis != OBISCode(0, 0, 1, 7, 0, 255)
+    assert obis != OBISCode(1, 0, 2, 7, 0, 255)
+    assert obis != OBISCode(1, 0, 1, 16, 0, 255)
+    assert obis != OBISCode(1, 0, 1, 7, 1, 255)
+
+
+def test_hash_of_obis():
+    obis = OBISCode(1, 0, 1, 7, 0, 255)
+    obis_diff = OBISCode(2, 0, 1, 7, 0, 255)
+    obis_same = OBISCode(1, 2, 1, 7, 0, 255)
+
+    assert hash(obis) == hash(obis_same)
+    assert hash(obis) != hash(obis_diff)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # See LICENSES/README.md for more information.
 #
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -14,8 +14,8 @@ from smartmeter_datacollector.smartmeter.hdlc_dlms_parser import HdlcDlmsParser
 from smartmeter_datacollector.smartmeter.meter_data import MeterDataPointTypes
 
 
-def prepare_parser(data: List[bytes], cosem_config: Cosem) -> HdlcDlmsParser:
-    parser = HdlcDlmsParser(cosem_config)
+def prepare_parser(data: List[bytes], cosem_config: Cosem, cipher_key: Optional[str] = None) -> HdlcDlmsParser:
+    parser = HdlcDlmsParser(cosem_config, cipher_key)
     for frame in data:
         parser.append_to_hdlc_buffer(frame)
         parser.extract_data_from_hdlc_frames()
@@ -60,6 +60,16 @@ def unencrypted_invalid_data_lg() -> List[bytes]:
 
 
 @pytest.fixture
+def unencrypted_valid_data_lg2() -> List[bytes]:
+    data_str: List[str] = []
+    data_str.append("7E A0 84 CE FF 03 13 12 8B E6 E7 00 E0 40 00 01 00 00 70 0F 00 03 B5 33 0C 07 E6 0B 16 02 10 25 1E FF 80 00 00 02 0B 01 0B 02 04 12 00 28 09 06 00 08 19 09 00 FF 0F 02 12 00 00 02 04 12 00 28 09 06 00 08 19 09 00 FF 0F 01 12 00 00 02 04 12 00 01 09 06 00 00 60 01 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 00 01 07 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 00 02 07 00 FF 0F 02 12 00 00 4C 21 7E")
+    data_str.append("7E A0 8B CE FF 03 13 EE E1 E0 40 00 02 00 00 7A 02 04 12 00 03 09 06 01 01 01 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 02 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 05 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 06 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 07 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 08 08 00 FF 0F 02 12 00 00 09 06 00 08 19 09 00 FF 09 08 34 34 33 33 8B 52 7E")
+    data_str.append("7E A0 3D CE FF 03 13 F2 84 E0 C0 00 03 00 00 2C 37 38 31 31 06 00 00 03 09 06 00 00 00 00 06 01 7F BF EB 06 00 43 7A DE 06 00 2F CD AE 06 00 00 33 BF 06 00 37 70 2E 06 00 F0 41 58 40 EF 7E")
+    data = list(map(lambda frag: bytes.fromhex(frag.replace(" ", "")), data_str))
+    return data
+
+
+@pytest.fixture
 def unencrypted_valid_data_iskra() -> List[bytes]:
     data_str: List[str] = []
     data_str.append("7E A8 A4 CF 02 23 03 99 96 E6 E7 00 0F 00 00 04 33 0C 07 E4 08 0F 06 06 13 2D 00 FF 88 80 02 1C 01 1C 02 04 12 00 28 09 06 00 06 19 09 00 FF 0F 02 12 00 00 02 04 12 00 28 09 06 00 06 19 09 00 FF 0F 01 12 00 00 02 04 12 00 01 09 06 00 00 2A 00 00 FF 0F 02 12 00 00 02 04 12 00 01 09 06 00 00 60 01 01 FF 0F 02 12 00 00 02 04 12 00 08 09 06 00 00 01 00 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 01 07 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 02 07 00 FF 0F 02 12 00 00 02 04 12 37 4F 7E")
@@ -67,5 +77,16 @@ def unencrypted_valid_data_iskra() -> List[bytes]:
     data_str.append("7E A8 A4 CF 02 23 03 99 96 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 05 08 01 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 05 08 02 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 06 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 06 08 01 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 06 08 02 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 07 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 07 08 01 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 07 08 02 FF 0F 02 12 00 00 02 04 12 00 03 B2 E4 7E")
     data_str.append("7E A8 A4 CF 02 23 03 99 96 09 06 01 01 08 08 00 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 08 08 01 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 01 08 08 02 FF 0F 02 12 00 00 02 04 12 00 03 09 06 01 00 0D 07 00 FF 0F 02 12 00 00 09 06 00 06 19 09 00 FF 09 10 49 53 4B 31 30 33 30 37 37 35 32 31 33 38 35 39 09 07 31 38 37 36 33 35 30 09 0C 07 E4 08 0F 06 06 13 2D 00 FF 88 80 06 00 00 00 00 06 00 00 00 00 06 00 00 00 00 06 00 00 00 00 06 00 5F 0E A5 06 00 2F 44 2F 06 00 2F CA 76 06 00 00 BE FE 7E")
     data_str.append("7E A0 55 CF 02 23 13 A2 33 00 00 06 00 00 00 00 06 00 00 00 00 06 00 05 47 7C 06 00 03 84 3F 06 00 01 C3 3D 06 00 00 00 09 06 00 00 00 09 06 00 00 00 00 06 00 00 00 00 06 00 00 00 00 06 00 00 00 00 06 00 01 0A F7 06 00 00 94 B0 06 00 00 76 47 12 00 00 12 7B 7E")
+    data = list(map(lambda frag: bytes.fromhex(frag.replace(" ", "")), data_str))
+    return data
+
+
+@pytest.fixture
+def encrypted_data_no_pushlist_lg() -> List[bytes]:
+    data_str: List[str] = []
+    data_str.append("7E A0 8B CE FF 03 13 EE E1 E6 E7 00 E0 40 00 01 00 00 77 DB 08 4C 47 5A 67 73 78 1F D0 82 01 03 30 00 06 90 3C EB 7B E1 75 48 BF D7 C3 6E DF 96 48 93 7D 7C 78 26 2B E5 FC FE E3 6B 41 D0 61 CF F3 FA 3A E6 91 8B FD C6 1F 95 67 19 E2 95 91 FC D6 D0 A1 98 D6 CA 49 CC DD 56 5F D3 8A 5F 9A 6C 8E AC 3A BE EE 11 0D 2E C4 EB B6 DC 10 43 D3 5A 8B C8 7D 42 0E 75 A2 3C 44 F4 08 B7 A7 31 F1 62 1F 84 86 F3 50 C3 A4 9D 02 06 B1 3A 7E")
+    data_str.append("7E A0 8B CE FF 03 13 EE E1 E0 40 00 02 00 00 7A 48 44 3E 98 6B 54 C0 4A 4E 84 AE 52 EC F1 89 4A CC 58 67 52 28 E2 45 6F 9B ED CD 22 79 03 FE 91 16 50 5C 90 02 A6 9A C4 5E F7 35 40 9B 4D 7E CE 2D 89 CD 86 F6 5B FB DF E6 1C 94 3F CE A4 CA 64 6C 3E EC BD 8C 38 BA 05 7B C5 21 DA 2C 08 E5 9B E8 FB B3 FE 59 27 94 D5 80 41 AF 33 2D C0 ED 7A 51 19 06 ED A5 24 07 95 81 9C 85 39 68 52 D7 9D 3A B7 B8 3B C7 30 23 F7 4B 5F 01 FE 7E")
+    data_str.append(
+        "7E A0 30 CE FF 03 13 86 F8 E0 C0 00 03 00 00 1F 1F FE C7 27 11 0F 74 B7 EF F4 1B 48 F7 47 B6 B6 A2 39 5B 42 BD 61 EA 18 7E D9 A0 99 8B 81 45 44 78 7E")
     data = list(map(lambda frag: bytes.fromhex(frag.replace(" ", "")), data_str))
     return data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@ import pytest
 from smartmeter_datacollector.smartmeter.cosem import Cosem, RegisterCosem
 from smartmeter_datacollector.smartmeter.hdlc_dlms_parser import HdlcDlmsParser
 from smartmeter_datacollector.smartmeter.meter_data import MeterDataPointTypes
+from smartmeter_datacollector.smartmeter.obis import OBISCode
 
 
 def prepare_parser(data: List[bytes], cosem_config: Cosem, cipher_key: Optional[str] = None) -> HdlcDlmsParser:
@@ -25,8 +26,8 @@ def prepare_parser(data: List[bytes], cosem_config: Cosem, cipher_key: Optional[
 @pytest.fixture
 def cosem_config_lg() -> Cosem:
     obis_registers = [
-        RegisterCosem("1.0.1.7.0.255", MeterDataPointTypes.ACTIVE_POWER_P.value),
-        RegisterCosem("1.0.2.7.0.255", MeterDataPointTypes.ACTIVE_POWER_N.value),
+        RegisterCosem(OBISCode(1, 0, 1, 7, 0), MeterDataPointTypes.ACTIVE_POWER_P.value),
+        RegisterCosem(OBISCode(1, 0, 2, 7, 0), MeterDataPointTypes.ACTIVE_POWER_N.value),
     ]
     return Cosem(
         fallback_id="fallback_id",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,16 @@ from typing import List
 import pytest
 
 from smartmeter_datacollector.smartmeter.cosem import Cosem, RegisterCosem
+from smartmeter_datacollector.smartmeter.hdlc_dlms_parser import HdlcDlmsParser
 from smartmeter_datacollector.smartmeter.meter_data import MeterDataPointTypes
+
+
+def prepare_parser(data: List[bytes], cosem_config: Cosem) -> HdlcDlmsParser:
+    parser = HdlcDlmsParser(cosem_config)
+    for frame in data:
+        parser.append_to_hdlc_buffer(frame)
+        parser.extract_data_from_hdlc_frames()
+    return parser
 
 
 @pytest.fixture


### PR DESCRIPTION
- The software parses DLMS messages that do not start with a push object list. Until now, the service crashed receiving such messages.
- The OBIS handling has been improved. Now a hashable dataclass `OBISCode` is used instead of strings which is more flexible.